### PR TITLE
inform about rename of google-webfonts to google-fonts in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ aur-packages
 
 My Arch Linux User Repository (AUR) packages:
 * [spotify-gnome-git](https://aur.archlinux.org/packages/spotify-gnome-git/)
-* [ttf-google-webfonts-git](https://aur.archlinux.org/packages/ttf-google-webfonts-git/)
+* [ttf-google-fonts-git](https://aur.archlinux.org/packages/ttf-google-fonts-git/)
+
+The aur package [ttf-google-webfonts-git](https://aur.archlinux.org/packages/ttf-google-webfonts-git/)
+has been renamed to
+[ttf-google-fonts-git](https://aur.archlinux.org/packages/ttf-google-fonts-git/)!
 
 For improvements/fixes to any package, please send me a pull request.


### PR DESCRIPTION
Took me a few seconds to find out, that google-webfonts has been renamed to google-fonts.

Adding a note in the README.md should help others to realize this even faster.
