### PR TITLE
ttf-google-fonts-git: use https instead of git

### DIFF
--- a/ttf-google-fonts-git/PKGBUILD
+++ b/ttf-google-fonts-git/PKGBUILD
@@ -68,7 +68,7 @@ conflicts=('adobe-source-code-pro-fonts'
            'ttf-fira-sans'
            'ttf-lato')
 provides=("${conflicts[@]}" 'ttf-font')
-source=("git://github.com/google/fonts.git")
+source=("https://github.com/google/fonts.git")
 md5sums=('SKIP')
 install=font.install
 


### PR DESCRIPTION
GitHub hasn't offered git:// links in a long time (even if it still exists), but nowadays git:// has no advatanges over https:// which is encrypted and port 443 is more likely to be open than whatever the git port was.
